### PR TITLE
ci(pages): Pages workflow uses root workspaces (clean)

### DIFF
--- a/.github/workflows/pages-miniapp.yml
+++ b/.github/workflows/pages-miniapp.yml
@@ -20,9 +20,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: pokerverse-miniapp/apps/web
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,7 +30,6 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: |
-            pokerverse-miniapp/apps/web/package-lock.json
             package-lock.json
 
       - name: Install
@@ -42,12 +38,12 @@ jobs:
       - name: Build
         env:
           VITE_ATLAS_CDN: https://cdn.pokerverse.siyahkare.com/atlas/latest
-        run: npm run build
+        run: npm run -w pokerverse-miniapp/apps/web build
 
       - name: Write CNAME
         run: |
-          echo "miniapp.pokerverse.siyahkare.com" > dist/CNAME
-          echo "nojekyll" > dist/.nojekyll
+          echo "miniapp.pokerverse.siyahkare.com" > pokerverse-miniapp/apps/web/dist/CNAME
+          echo "nojekyll" > pokerverse-miniapp/apps/web/dist/.nojekyll
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Install at repo root with npm ci; build miniapp via npm -w pokerverse-miniapp/apps/web build; correct dist paths.